### PR TITLE
Change wrap-guide color

### DIFF
--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -10,7 +10,7 @@
 @syntax-background-color: @dark-gray;
 
 // Guide colors
-@syntax-wrap-guide-color: @dark-gray;
+@syntax-wrap-guide-color: lighten(@dark-gray, 5%);;
 @syntax-indent-guide-color: @gray;
 @syntax-invisible-character-color: lighten(@gray, 5%);
 


### PR DESCRIPTION
Wrap-guide was the same color of the background, so it was impossible to see it.

There is an option in Atom's settings to whom does not want the wrap guide.
